### PR TITLE
Version bumb on renovate update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,7 @@
           "name": "Bump version on config template update",
           "filePatterns": ["pyproject.toml"],
           "matchStrings": ["version\\s*=\\s*\"(?<version>[^\\s\"]+)\""],
-          "bumpType": "{{#if isMajor}}major{{else if isMinor}}minor{{else}}patch{{/if}}"
+          "bumpType": "patch"
         }
       ]
     }


### PR DESCRIPTION
@kapsner  can you test this by downgrading a dependency version in `src/commit_hooks/templates/configs/pre-commit-cfg.yaml` and manually triggering a Renovate run, to verify that `pyproject.toml` version gets bumped automatically.

closes #12